### PR TITLE
making recipent , subject , email_body as not mandatory fields

### DIFF
--- a/restAPI.py
+++ b/restAPI.py
@@ -14,9 +14,9 @@ class ConfigSchema(Schema):
     frequency = fields.List(fields.Str(), required=True)
     report_name = fields.Str(required=True)
     query = fields.Str(required=True)
-    recipents = fields.List(fields.Str(), required=True)
-    subject = fields.Str(required=True)
-    email_body = fields.Str(required=True)
+    recipents = fields.List(fields.Str(), required=False)
+    subject = fields.Str(required=False)
+    email_body = fields.Str(required=False)
     transfer_type = fields.Str(required=True)
 
     class Meta:


### PR DESCRIPTION
making recipent , subject , email_body as not mandatory fields as this is only required for smtp transfer_type